### PR TITLE
Put Files

### DIFF
--- a/Client/Commands.cs
+++ b/Client/Commands.cs
@@ -42,10 +42,7 @@ namespace Client
         [Verb("put", HelpText = "Upload files to remote server")]
         public class Put
         {
-            [Value(0, MetaName = "file", HelpText = "File to upload to remote server")]
-            public string? File { get; set; }
-
-            [Option('m', "multiple", Required = false, HelpText = "Upload multiple files to remote")]
+            [Value(0, MetaName = "files", HelpText = "Files to upload to remote server")]
             public IEnumerable<string>? Files { get; set; }
         }
 

--- a/Client/Get.cs
+++ b/Client/Get.cs
@@ -279,10 +279,14 @@ namespace Client
             string tempPath;
 
             // For absolute path ex c:\dev
-            if (args[1][1].Equals(':'))
+            if (args.Count() == 3 && args[2][1].Equals(':'))
+			{
+                tempPath = args[2];
+			}
+            else if (args.Count() == 2 && args[1][1].Equals(':'))
 			{
                 tempPath = args[1];
-			}
+            }
             else
 			{
                 tempPath = path.Local;

--- a/Client/Get.cs
+++ b/Client/Get.cs
@@ -276,13 +276,24 @@ namespace Client
         //Method that changes the current local directory
         private static int ChangeLocalDirectory(in FtpClient client, ref Program.FilePath path, in string[] args, int index)
         {
-            string tempPath = path.Local;
-            //find the number of args provided and where the
-            //directory that is wanting to be displayed is located
-            if (index + 3 == args.Length)//passes when the users provides -l flag
-                tempPath += args[2] + "/";
-            else if (index + 2 == args.Length)//passes when the user does not provide -l flag
-                tempPath += args[1] + "/";
+            string tempPath;
+
+            // For absolute path ex c:\dev
+            if (args[1][1].Equals(':'))
+			{
+                tempPath = args[1];
+			}
+            else
+			{
+                tempPath = path.Local;
+                //find the number of args provided and where the
+                //directory that is wanting to be displayed is located
+                if (index + 3 == args.Length)//passes when the users provides -l flag
+                    tempPath += args[2] + "/";
+                else if (index + 2 == args.Length)//passes when the user does not provide -l flag
+                    tempPath += args[1] + "/";
+            }
+
 
             if (!Directory.Exists(tempPath))
             {

--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -58,7 +58,7 @@ namespace Client
                 (Commands.Get opts) => Get.File(ref client, opts),
                 (Commands.Disconnect opts) => Connection.Disconnect(ref client, ref logger),
                 (Commands.Quit opts) => Connection.Exit(),
-                (Commands.Put opts) => Put.File(ref client, opts),
+                (Commands.Put opts) => Put.File(ref client, opts, in path),
                 (Commands.CreateDirectory opts) => Put.Create(ref client, opts),
                 (Commands.Delete opts) => Modify.Delete(ref client, opts),
                 (Commands.Permissions opts) => Modify.Permissions(ref client, opts),

--- a/Client/Put.cs
+++ b/Client/Put.cs
@@ -23,11 +23,17 @@ namespace Client
 				foreach (string fp in file.Files)
 				{
 					if (fp.Length > 1 && fp[1] == ':')
+					{
 						files[i] = fp;
+					}
 					else
-						files[i] = path.Local + fp;
+					{
+						files[i] = path.Local + '\\' + fp;
+					}
 					if (!System.IO.File.Exists(files[i]))
+					{
 						throw new Exception("\"" + fp + "\" is not a valid filepath!");
+					}
 					++i;
 				}
 

--- a/Client/Put.cs
+++ b/Client/Put.cs
@@ -27,7 +27,9 @@ namespace Client
 						files[i] = fp;
 					}
 					else
+					{
 						files[i] = path.Local + fp;
+					}
 					if (!System.IO.File.Exists(files[i]))
 					{
 						throw new Exception("\"" + fp + "\" is not a valid filepath!");
@@ -89,11 +91,7 @@ namespace Client
 			{
 				throw new Exception("Failed to upload file: " + localPath);
 			}
-			else
-			{
-				Console.WriteLine("Successfully uploaded file: " + fullRemotePath);     // load bar seems to overwrite this?
-				return 1;
-			}
+			return 1;
 		}
 
 		public static int MultipleFiles(ref FtpClient client, string[] files, in Program.FilePath path, ProgressBarOptions options)
@@ -107,8 +105,7 @@ namespace Client
 				progress.Report(upload.Progress / 100);
 			};
 
-			int number = client.UploadFiles(files, path.Remote, FtpRemoteExists.Overwrite, true, FtpVerify.OnlyChecksum, FtpError.Throw, progress);
-			Console.WriteLine(number + " files uploaded successfully!");    // load bar seems to overwrite this?
+			client.UploadFiles(files, path.Remote, FtpRemoteExists.Overwrite, true, FtpVerify.OnlyChecksum, FtpError.Throw, progress);
 			return 1;
 		}
 

--- a/Client/Put.cs
+++ b/Client/Put.cs
@@ -25,7 +25,7 @@ namespace Client
 					if (fp.Length > 1 && fp[1] == ':')
 						files[i] = fp;
 					else
-						files[i] = path.Local + fp;
+						files[i] = path.Local + '\\' + fp;
 					if (!System.IO.File.Exists(files[i]))
 						throw new Exception("\"" + fp + "\" is not a valid filepath!");
 					++i;

--- a/Client/Put.cs
+++ b/Client/Put.cs
@@ -7,14 +7,14 @@ namespace Client
 	{
 		public static int File(ref FtpClient client, Commands.Put file, in Program.FilePath path)
 		{
-			Console.WriteLine("file: " + file.File);
-
 			try
 			{
 				if (!client.IsAuthenticated)
 				{
 					throw new Exception("Error: No connection to remote server!");
 				}
+				Console.WriteLine("");
+
 
 				// Progress bar related code //
 				var options = new ProgressBarOptions
@@ -24,12 +24,6 @@ namespace Client
 					BackgroundColor = ConsoleColor.DarkGray,
 					BackgroundCharacter = '\u2593'
 				};
-				//var childOptions = new ProgressBarOptions
-				//{
-				//	ForegroundColor = ConsoleColor.Green,
-				//	BackgroundColor = ConsoleColor.DarkGreen,
-				//	ProgressCharacter = '─'
-				//};
 
 				using var progressBar = new ProgressBar(10000, "uploaded", options);
 				Action<FtpProgress> progress = delegate (FtpProgress upload)
@@ -37,17 +31,12 @@ namespace Client
 					var progress = progressBar.AsProgress<double>();
 					progress.Report(upload.Progress / 100);
 				};
+				// Progress bar related code 
 
 
 				if (file.Files != null && file.Files.Count() > 1)
 				{
-					//int i = 0;
-
-					//foreach (string file in files)
-					//{
-
-					//}
-
+					//foreach (string file in files){}
 					return MultipleFiles(ref client, file.Files, path, progress);
 				}
 				else
@@ -67,8 +56,11 @@ namespace Client
 		{
 			try
 			{
-				string fullRemotePath = path.Remote + Path.GetFileName(file.File);
-				client.UploadFile(@file.File, @fullRemotePath, FtpRemoteExists.Overwrite, true, FtpVerify.OnlyChecksum, progress);
+				if (file.Files == null)
+					throw new Exception("No argument passed!");
+				string localPath = file.Files.ElementAt(0);
+				string fullRemotePath = path.Remote + Path.GetFileName(localPath);
+				client.UploadFile(@localPath, @fullRemotePath, FtpRemoteExists.Overwrite, true, FtpVerify.OnlyChecksum, progress);
 				return 1;
 			}
 			catch (Exception e)

--- a/Client/Put.cs
+++ b/Client/Put.cs
@@ -1,17 +1,51 @@
 ﻿using System;
 using FluentFTP;
+using ShellProgressBar;
 namespace Client
 {
     public static class Put
     {
-        public static int File(ref FtpClient client, Commands.Put file)
+        public static int File(ref FtpClient client, Commands.Put file, in Program.FilePath path)
         {
             Console.WriteLine("file: " + file.File);
 
-            if (file.Files.Count() > 1)
-                return MultipleFiles(file.Files);
+                if (!client.IsAuthenticated)
+                {
+                    throw new Exception("Error: No connection to remote server!");
+                }
+                if (file.Files.Count() > 1)
+                    return MultipleFiles(file.Files);
+
+                var options = new ProgressBarOptions
+                {
+                    ForegroundColor = ConsoleColor.Yellow,
+                    ForegroundColorDone = ConsoleColor.DarkGreen,
+                    BackgroundColor = ConsoleColor.DarkGray,
+                    BackgroundCharacter = '\u2593'
+                };
+
+                using var progressBar = new ProgressBar(10000, "uploaded", options);
+
+                Action<FtpProgress> progress = delegate (FtpProgress download)
+                {
+                    var progress = progressBar.AsProgress<double>();
+                    progress.Report(download.Progress / 100);
+                };
+
+            try
+            {
+                string fullRemotePath = path.Remote + Path.GetFileName(file.File);
+                Console.WriteLine(fullRemotePath);
+                client.UploadFile(@file.File, @fullRemotePath, FtpRemoteExists.Overwrite, true, FtpVerify.OnlyChecksum, progress);
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine(e.InnerException);
+                return -1;
+            }
             return 0;
         }
+
 
         public static int MultipleFiles(IEnumerable<string> files)
         {

--- a/Client/Put.cs
+++ b/Client/Put.cs
@@ -34,7 +34,7 @@ namespace Client
 					BackgroundCharacter = '\u2593'
 				};
 
-				if (file.Files != null && file.Files.Count() > 1)
+				if (file.Files.Count() > 1)
 				{
 					return MultipleFiles(ref client, file.Files, path, options);
 				}

--- a/Client/Put.cs
+++ b/Client/Put.cs
@@ -28,7 +28,7 @@ namespace Client
 					}
 					else
 					{
-						files[i] = path.Local + fp;
+						files[i] = path.Local + "\\" + fp;
 					}
 					if (!System.IO.File.Exists(files[i]))
 					{

--- a/Client/Put.cs
+++ b/Client/Put.cs
@@ -3,105 +3,117 @@ using FluentFTP;
 using ShellProgressBar;
 namespace Client
 {
-    public static class Put
-    {
-        public static int File(ref FtpClient client, Commands.Put file, in Program.FilePath path)
-        {
-            Console.WriteLine("file: " + file.File);
+	public static class Put
+	{
+		public static int File(ref FtpClient client, Commands.Put file, in Program.FilePath path)
+		{
+			Console.WriteLine("file: " + file.File);
 
-            if (!client.IsAuthenticated)
-            {
-                throw new Exception("Error: No connection to remote server!");
-            }
-            if (file.Files.Count() > 1)
-                return MultipleFiles(ref client, file.Files, path);
+			try
+			{
+				if (!client.IsAuthenticated)
+				{
+					throw new Exception("Error: No connection to remote server!");
+				}
 
-            // Progress bar related code //
-            const int totalTicks = 10;
-            var options = new ProgressBarOptions
-            {
-                ForegroundColor = ConsoleColor.Yellow,
-                ForegroundColorDone = ConsoleColor.DarkGreen,
-                BackgroundColor = ConsoleColor.DarkGray,
-                BackgroundCharacter = '\u2593'
-            };
-            //var childOptions = new ProgressBarOptions
-            //{
-            //    ForegroundColor = ConsoleColor.Green,
-            //    BackgroundColor = ConsoleColor.DarkGreen,
-            //    ProgressCharacter = '─'
-            //};
-            //using (var pbar = new ProgressBar(totalTicks, "main progressbar", options))
-            //{
-            //    TickToCompletion(pbar, totalTicks, sleep: 10, childAction: () =>
-            //    {
-            //        using (var child = pbar.Spawn(totalTicks, "child actions", childOptions))
-            //        {
-            //            TickToCompletion(child, totalTicks, sleep: 100);
-            //        }
-            //    });
-            //}
+				// Progress bar related code //
+				var options = new ProgressBarOptions
+				{
+					ForegroundColor = ConsoleColor.Yellow,
+					ForegroundColorDone = ConsoleColor.DarkGreen,
+					BackgroundColor = ConsoleColor.DarkGray,
+					BackgroundCharacter = '\u2593'
+				};
+				//var childOptions = new ProgressBarOptions
+				//{
+				//	ForegroundColor = ConsoleColor.Green,
+				//	BackgroundColor = ConsoleColor.DarkGreen,
+				//	ProgressCharacter = '─'
+				//};
 
-            using var progressBar = new ProgressBar(10000, "uploaded", options);
-
-            Action<FtpProgress> progress = delegate (FtpProgress download)
-            {
-                var progress = progressBar.AsProgress<double>();
-                progress.Report(download.Progress / 100);
-            };
-
-            try
-            {
-                string fullRemotePath = path.Remote + Path.GetFileName(file.File);
-                client.UploadFile(@file.File, @fullRemotePath, FtpRemoteExists.Overwrite, true, FtpVerify.OnlyChecksum, progress);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e.InnerException);
-                return -1;
-            }
-            return 0;
-        }
+				using var progressBar = new ProgressBar(10000, "uploaded", options);
+				Action<FtpProgress> progress = delegate (FtpProgress upload)
+				{
+					var progress = progressBar.AsProgress<double>();
+					progress.Report(upload.Progress / 100);
+				};
 
 
-        public static int MultipleFiles(ref FtpClient client, IEnumerable<string> files, in Program.FilePath path)
-        {
-            try
-            {
-                client.UploadFiles(files, path.Remote, FtpRemoteExists.Overwrite, true, FtpVerify.OnlyChecksum);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e.InnerException);
-                return -1;
-            }
-            //foreach (string file in files)
-            //    Console.WriteLine(file); // remove this
+				if (file.Files != null && file.Files.Count() > 1)
+				{
+					//int i = 0;
 
-            return 0;
-        }
+					//foreach (string file in files)
+					//{
 
-        public static int Create(ref FtpClient client, Commands.CreateDirectory directory)
-        {
-            if (client.IsAuthenticated)
-            {
-                if (client.DirectoryExists(directory.Name))
-                    Console.WriteLine("ERROR: Directory already exists\n");
-                else
-                    client.CreateDirectoryAsync(directory.Name);
+					//}
 
-                return 0;
-            }
-            else
-            {
-                Console.WriteLine("ERROR: Not connected to remote server!\n");
-                return -1;
-            }
-        }
+					return MultipleFiles(ref client, file.Files, path, progress);
+				}
+				else
+				{
+					return SingleFile(ref client, file, path, progress);
+				}
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e.Message);
+				return -1;
+			}
+			return 0;
+		}
 
-        public static int Copy(ref FtpClient client, Commands.Copy file)
-        {
-            return 0;
-        }
-    }
+		public static int SingleFile(ref FtpClient client, Commands.Put file, in Program.FilePath path, Action<FtpProgress> progress)
+		{
+			try
+			{
+				string fullRemotePath = path.Remote + Path.GetFileName(file.File);
+				client.UploadFile(@file.File, @fullRemotePath, FtpRemoteExists.Overwrite, true, FtpVerify.OnlyChecksum, progress);
+				return 1;
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e.InnerException);
+				return -1;
+			}
+		}
+
+		public static int MultipleFiles(ref FtpClient client, IEnumerable<string> files, in Program.FilePath path, Action<FtpProgress> progress)
+		{
+			try
+			{
+				int number = client.UploadFiles(files, path.Remote, FtpRemoteExists.Overwrite, true, FtpVerify.OnlyChecksum, FtpError.Throw, progress);
+				Console.WriteLine(number + " files uploaded successfully");
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine(e.InnerException);
+				return -1;
+			}
+			return 0;
+		}
+
+		public static int Create(ref FtpClient client, Commands.CreateDirectory directory)
+		{
+			if (client.IsAuthenticated)
+			{
+				if (client.DirectoryExists(directory.Name))
+					Console.WriteLine("ERROR: Directory already exists\n");
+				else
+					client.CreateDirectoryAsync(directory.Name);
+
+				return 0;
+			}
+			else
+			{
+				Console.WriteLine("ERROR: Not connected to remote server!\n");
+				return -1;
+			}
+		}
+
+		public static int Copy(ref FtpClient client, Commands.Copy file)
+		{
+			return 0;
+		}
+	}
 }

--- a/Client/Put.cs
+++ b/Client/Put.cs
@@ -91,7 +91,7 @@ namespace Client
 			{
 				throw new Exception("Failed to upload file: " + localPath);
 			}
-			return 1;
+			return 0;
 		}
 
 		public static int MultipleFiles(ref FtpClient client, string[] files, in Program.FilePath path, ProgressBarOptions options)
@@ -106,7 +106,7 @@ namespace Client
 			};
 
 			client.UploadFiles(files, path.Remote, FtpRemoteExists.Overwrite, true, FtpVerify.OnlyChecksum, FtpError.Throw, progress);
-			return 1;
+			return 0;
 		}
 
 		public static int Create(ref FtpClient client, Commands.CreateDirectory directory)


### PR DESCRIPTION
This will add the functionality to put files onto the FTP server. Instead of a flag, the put command will see if you have more than one argument and choose either single or multiple file upload.

It should work with either relative or absolute paths though I had some trouble with that so let me know if it fails!

I also did a minor patch to the CD command to allow for using absolute paths in the local directory.

There is a known issue where the progress bar will overwrite some Console.WriteLine()'s but since the bar shows 100% if it succeeds this is not a huge deal.